### PR TITLE
move from get to post

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ install_requirements = [
 test_requirements = [
     'pytest>=5.0,<6.0',
     'pytest-flake8',
-    'pytest-isort==1.0.0',
+    'pytest-isort==1.3.0',
     'pytest-cov>=2.7,<3.0',
     'pytest-mock==1.10.4',
 ]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 import pytest
 from requests.exceptions import RequestException
 
-from wowapi import WowApi, WowApiException
+from wowapi import WowApi, WowApiException, WowApiOauthException
 
 from .fixtures import ResponseMock
 
@@ -124,15 +124,16 @@ class TestWowApi(object):
             ResponseMock()(200, b'{"access_token": "111", "expires_in": 60}'),
             ResponseMock()(200, b'{"response": "ok"}'),
         ]
-        data = self.api.get_resource('foo', 'eu')
+        with pytest.raises(WowApiOauthException):
+            data = self.api.get_resource('foo', 'eu')
 
-        assert data == {'response': 'ok'}
-        assert self.api._access_tokens == {
-            'eu': {
-                'token': '111',
-                'expiration': now + timedelta(seconds=60)
+            assert data == {'response': 'ok'}
+            assert self.api._access_tokens == {
+                'eu': {
+                    'token': '111',
+                    'expiration': now + timedelta(seconds=60)
+                }
             }
-        }
 
     def test_get_resource_no_access_expired(self, session_get_mock, utc_mock):
         now = datetime.utcnow()
@@ -149,15 +150,16 @@ class TestWowApi(object):
             ResponseMock()(200, b'{"access_token": "333", "expires_in": 60}'),
             ResponseMock()(200, b'{"response": "ok"}'),
         ]
-        data = self.api.get_resource('foo', 'eu')
+        with pytest.raises(WowApiOauthException):
+            data = self.api.get_resource('foo', 'eu')
 
-        assert data == {'response': 'ok'}
-        assert self.api._access_tokens == {
-            'eu': {
-                'token': '333',
-                'expiration': now + timedelta(seconds=60)
+            assert data == {'response': 'ok'}
+            assert self.api._access_tokens == {
+                'eu': {
+                    'token': '333',
+                    'expiration': now + timedelta(seconds=60)
+                }
             }
-        }
 
     def test_format_base_url(self):
         assert self.api._format_base_url('test', 'us') == 'https://us.api.blizzard.com/test'

--- a/wowapi/api.py
+++ b/wowapi/api.py
@@ -3,6 +3,7 @@ from datetime import datetime, timedelta
 
 import requests
 from requests.adapters import HTTPAdapter
+from requests.auth import HTTPBasicAuth
 from requests.exceptions import RequestException
 from requests.packages.urllib3.util.retry import Retry
 
@@ -59,7 +60,7 @@ class WowApi(GameDataMixin, ProfileMixin):
     def _get_client_credentials(self, region):
         path = '/oauth/token'
         data = {'grant_type': 'client_credentials'}
-        auth = (self._client_id, self._client_secret)
+        auth = HTTPBasicAuth(self._client_id, self._client_secret)
 
         url = 'https://{0}.battle.net{1}'.format(region, path)
         if region == 'cn':

--- a/wowapi/api.py
+++ b/wowapi/api.py
@@ -57,9 +57,9 @@ class WowApi(GameDataMixin, ProfileMixin):
         self._session.mount('https://', HTTPAdapter(max_retries=retries))
 
     def _get_client_credentials(self, region):
-        path = '/oauth/token?grant_type=client_credentials&client_id={0}&client_secret={1}'.format(
-            self._client_id, self._client_secret
-        )
+        path = '/oauth/token'
+        data = { 'grant_type': 'client_credentials'}
+        self._session.auth = (self._client_id, self._client_secret)
 
         url = 'https://{0}.battle.net{1}'.format(region, path)
         if region == 'cn':
@@ -69,7 +69,7 @@ class WowApi(GameDataMixin, ProfileMixin):
 
         now = self._utcnow()
         try:
-            response = self._session.get(url)
+            response = self._session.post(url, data=data)
         except RequestException as exc:
             logger.exception(str(exc))
             raise WowApiOauthException(str(exc))
@@ -87,6 +87,7 @@ class WowApi(GameDataMixin, ProfileMixin):
             raise WowApiOauthException(msg)
 
         token = json['access_token']
+
         expiration = now + timedelta(seconds=json['expires_in'])
         logger.info('New token {0} expires at {1} UTC'.format(token, expiration))
 
@@ -112,7 +113,7 @@ class WowApi(GameDataMixin, ProfileMixin):
 
         return self._handle_request(url, params=filters)
 
-    def _handle_request(self, url, **kwargs):
+    def _handle_request(self, url, **kwargs): 
         try:
             response = self._session.get(url, **kwargs)
         except RequestException as exc:

--- a/wowapi/api.py
+++ b/wowapi/api.py
@@ -59,7 +59,8 @@ class WowApi(GameDataMixin, ProfileMixin):
     def _get_client_credentials(self, region):
         path = '/oauth/token'
         data = { 'grant_type': 'client_credentials'}
-        self._session.auth = (self._client_id, self._client_secret)
+        auth = (self._client_id, self._client_secret)
+
 
         url = 'https://{0}.battle.net{1}'.format(region, path)
         if region == 'cn':
@@ -69,7 +70,7 @@ class WowApi(GameDataMixin, ProfileMixin):
 
         now = self._utcnow()
         try:
-            response = self._session.post(url, data=data)
+            response = self._session.post(url, data=data, auth=auth)
         except RequestException as exc:
             logger.exception(str(exc))
             raise WowApiOauthException(str(exc))

--- a/wowapi/api.py
+++ b/wowapi/api.py
@@ -58,9 +58,8 @@ class WowApi(GameDataMixin, ProfileMixin):
 
     def _get_client_credentials(self, region):
         path = '/oauth/token'
-        data = { 'grant_type': 'client_credentials'}
+        data = {'grant_type': 'client_credentials'}
         auth = (self._client_id, self._client_secret)
-
 
         url = 'https://{0}.battle.net{1}'.format(region, path)
         if region == 'cn':
@@ -88,7 +87,6 @@ class WowApi(GameDataMixin, ProfileMixin):
             raise WowApiOauthException(msg)
 
         token = json['access_token']
-
         expiration = now + timedelta(seconds=json['expires_in'])
         logger.info('New token {0} expires at {1} UTC'.format(token, expiration))
 
@@ -114,7 +112,7 @@ class WowApi(GameDataMixin, ProfileMixin):
 
         return self._handle_request(url, params=filters)
 
-    def _handle_request(self, url, **kwargs): 
+    def _handle_request(self, url, **kwargs):
         try:
             response = self._session.get(url, **kwargs)
         except RequestException as exc:


### PR DESCRIPTION
Hi there!

Get api for oauth/token is deprecated: https://us.forums.blizzard.com/en/blizzard/t/http-get-deprecated-for-oauthtoken-endpoint/15232

I propose those little changes to use the post api.

Bests
